### PR TITLE
Modify Resnet for small images and use SGD

### DIFF
--- a/notebooks/image_classification.py
+++ b/notebooks/image_classification.py
@@ -19,7 +19,6 @@ args.max_steps = 10
 args.limit_val_batches = 10
 args.limit_test_batches = 10
 args.fast_dev_run = False
-args.progress_bar_refresh_rate = 20
 args.max_epochs = 1
 
 # args.predict_only = True
@@ -27,5 +26,3 @@ args.max_epochs = 1
 
 # %%
 main(args)
-
-# %%


### PR DESCRIPTION
This PR modifies the Resnet for use with tiny images and switches to using SGD among other small changes. This follows the setup in https://github.com/PyTorchLightning/pytorch-lightning/blob/master/notebooks/07-cifar10-baseline.ipynb

The accuracy on CIFAR10 is now 94% up from 85%, which takes around ~7 mins on a Tesla V100. It seems that the modification to the Resnet made most of the difference, and the switch to SGD is only worth 0.01, and I'm not too confident about that increase.

```
python -m pytorch_models.image_classification --aws_batch     --default_root_dir s3://raster-vision-lf-dev/research/lightning/cifar10/3-25-2021g     --max_epochs 40
```
