### PR TITLE
Add script to fine-tune SWAV on RV chips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-runtime
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu16.04
+
+RUN apt-get update && apt-get install -y wget=1.* python-opengl && apt-get clean
+
+RUN wget -q -O ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh && \
+     chmod +x ~/miniconda.sh && \
+     ~/miniconda.sh -b -p /opt/conda && \
+     rm ~/miniconda.sh
+ENV PATH /opt/conda/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
+RUN conda install -y python=3.7
+RUN python -m pip install --upgrade pip
 
 RUN conda install -y notebook=6.1.* matplotlib=3.3.* scikit-learn=0.23.*
-RUN apt-get update && apt-get install -y python-opengl && apt-get clean
+RUN pip install torch==1.7.*
 RUN pip install gym==0.18.* pyvirtualdisplay==2.0 Box2D==2.3.*
 
 # https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html
@@ -14,6 +25,9 @@ RUN pip install torch-geometric
 RUN pip install ipywidgets==7.6.3
 RUN pip install pytorch-lightning==1.2.4
 RUN pip install awscli==1.19.35 boto3==1.17.35
+RUN pip install pytorch-lightning-bolts==0.3.2 opencv-python==4.5.1.48
+RUN pip install torchvision==0.8.*
+RUN pip install s3fs==0.6.0
 
 ENV PYTHONPATH=/opt/src/:$PYTHONPATH
 COPY notebooks /opt/src/notebooks/

--- a/docker/run
+++ b/docker/run
@@ -91,6 +91,7 @@ fi
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     docker run ${RUNTIME} ${NAME} --rm -it \
+        --shm-size=8G \
         -v ${REPO_ROOT}/:/opt/src/ \
         -v $PTM_DATA_DIR:/opt/data \
         ${TENSORBOARD} ${AWS} ${JUPYTER} ${DEBUG} \

--- a/pytorch_models/train_swav.py
+++ b/pytorch_models/train_swav.py
@@ -1,0 +1,314 @@
+import math
+import os
+from os.path import join
+from argparse import ArgumentParser
+from typing import Callable, Optional, Any
+import glob
+import sys
+import random
+import tempfile
+import zipfile
+import uuid
+from collections import OrderedDict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from torch import distributed as dist
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+from torch.optim.optimizer import Optimizer
+from torchvision.datasets.folder import default_loader
+
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import ModelCheckpoint, LearningRateMonitor
+from pytorch_lightning.core.datamodule import LightningDataModule
+from pl_bolts.models.self_supervised.swav.transforms import (
+    SwAVEvalDataTransform, SwAVTrainDataTransform)
+from pl_bolts.transforms.dataset_normalizations import (
+    imagenet_normalization)
+from pl_bolts.models.self_supervised import SwAV
+
+from pytorch_models.utils import save_json, s3_sync, batch_submit, S3SyncCallback
+
+
+class CustomDataset(Dataset):
+    def __init__(self, data_dir, split, transform=None):
+        self.data_dir = data_dir
+        self.split = split
+        self.transform = transform
+        self.img_paths = glob.glob(
+            join(data_dir, '**', split, 'img', '*.png'), recursive=True)
+
+        self.img_paths.sort()
+        random.seed(1234)
+        random.shuffle(self.img_paths)
+
+    def __getitem__(self, ind):
+        img_path = self.img_paths[ind]
+        img = default_loader(img_path)
+        if self.transform:
+            img = self.transform(img)
+        return img, 0
+
+    def __len__(self):
+        return len(self.img_paths)
+
+
+class CustomDataModule(LightningDataModule):
+    name = 'custom'
+
+    def __init__(
+        self,
+        data_dir: str,
+        image_size: int = 224,
+        num_workers: int = 16,
+        batch_size: int = 32,
+        shuffle: bool = False,
+        pin_memory: bool = False,
+        drop_last: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.image_size = image_size
+        self.dims = (3, self.image_size, self.image_size)
+        self.data_dir = data_dir
+        self.num_workers = num_workers
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.pin_memory = pin_memory
+        self.drop_last = drop_last
+        self.num_samples = None
+
+    def prepare_data(self) -> None:
+        ds = CustomDataset(self.data_dir, split='train')
+        self.num_samples = len(ds)
+        self.sz = ds[0][0].size
+
+    def size(self):
+        return self.sz
+
+    def train_dataloader(self) -> DataLoader:
+        transforms = self.train_transform() if self.train_transforms is None else self.train_transforms
+        dataset = CustomDataset(self.data_dir, split='train', transform=transforms)
+        loader: DataLoader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            pin_memory=self.pin_memory
+        )
+        return loader
+
+    def val_dataloader(self) -> DataLoader:
+        transforms = self.train_transform() if self.val_transforms is None else self.val_transforms
+        dataset = CustomDataset(self.data_dir, split='valid', transform=transforms)
+        loader: DataLoader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            pin_memory=self.pin_memory
+        )
+        return loader
+
+    def test_dataloader(self) -> DataLoader:
+        return self.val_dataloader()
+
+
+def save_backbone(swav_model, output_path):
+    state_dict = swav_model.model.state_dict()
+    keys_to_remove = [
+        key for key in state_dict
+        if key.startswith('projection_head') or key.startswith('prototypes')]
+
+    new_state_dict = OrderedDict()
+    for key, value in state_dict.items():
+        if key not in keys_to_remove:
+            new_key = 'backbone.' + key
+            new_state_dict[new_key] = value
+
+    torch.save(new_state_dict, output_path)
+
+
+class DataPlotter():
+    def __init__(self, dm):
+        self.dm = dm
+
+    def plot_sample(self, ax, x):
+        x = x.permute([1, 2, 0])
+        mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 1, 3)
+        std = torch.tensor([0.229, 0.224, 0.225]).view(1, 1, 3)
+        x = (x * std) + mean
+        ax.imshow(x.numpy())
+
+    def plot_batch(self, x):
+        x = x[1]
+        batch_sz = x.shape[0]
+        nrows = ncols = math.ceil(math.sqrt(batch_sz))
+        fig, axs = plt.subplots(nrows, ncols, squeeze=False, figsize=(2*nrows, 2*ncols))
+        axs = axs.flatten()
+        for ind, ax in enumerate(axs):
+            if ind < batch_sz:
+                ax = axs[ind]
+                self.plot_sample(ax, x[ind])
+            ax.axis('off')
+
+        fig.tight_layout()
+        return fig
+
+    def plot_dl(self, dl, out_path=None):
+        x, _ = next(iter(dl))
+        fig = self.plot_batch(x)
+        if out_path is not None:
+            fig.savefig(out_path)
+
+    def plot_dataloaders(self, out_dir=None):
+        os.makedirs(out_dir, exist_ok=True)
+        for split in ['train', 'val', 'test']:
+            out_path = None if out_dir is None else join(out_dir, f'{split}.png')
+            dl = getattr(self.dm, f'{split}_dataloader')()
+            self.plot_dl(dl, out_path=out_path)
+
+def main(args):
+    os.makedirs('/opt/data/tmp/', exist_ok=True)
+    with tempfile.TemporaryDirectory(dir='/opt/data/tmp/') as tmp_dir:
+        root_dir = args.default_root_dir
+        orig_root_dir = root_dir
+        if root_dir.startswith('s3://'):
+            new_root_dir = join(tmp_dir, 'output')
+            s3_sync(root_dir, new_root_dir)
+            root_dir = new_root_dir
+            args.default_root_dir = root_dir
+        else:
+            os.makedirs(root_dir, exist_ok=True)
+
+        data_dir = args.data_dir
+        if data_dir.startswith('s3://'):
+            new_data_dir = join(tmp_dir, 'data')
+            s3_sync(data_dir, new_data_dir)
+            data_dir = new_data_dir
+        proc_data_dir = join(tmp_dir, 'processed_data')
+        os.makedirs(proc_data_dir, exist_ok=True)
+        zip_uris = glob.glob(join(data_dir, '*.zip'))
+        for zip_uri in zip_uris:
+            with zipfile.ZipFile(zip_uri, 'r') as zipf:
+                _proc_data_dir = join(proc_data_dir, str(uuid.uuid4()))
+                zipf.extractall(_proc_data_dir)
+        args.data_dir = proc_data_dir
+
+        args.gpus = torch.cuda.device_count()
+        args.dataset = 'imagenet'
+        args.maxpool1 = True
+        args.first_conv = True
+        normalization = imagenet_normalization()
+
+        args.size_crops = [224, 96]
+        args.nmb_crops = [2, 6]
+        args.min_scale_crops = [0.14, 0.05]
+        args.max_scale_crops = [1., 0.14]
+        args.gaussian_blur = True
+        args.jitter_strength = 1.
+
+        args.lars_wrapper = True
+        args.nmb_prototypes = 3000
+        args.online_ft = False
+
+        dm = CustomDataModule(
+            data_dir=args.data_dir, batch_size=args.batch_size,
+            num_workers=args.num_workers)
+        dm.prepare_data()
+
+        args.num_samples = dm.num_samples
+        args.input_height = dm.size()[-1]
+
+        dm.train_transforms = SwAVTrainDataTransform(
+            normalize=normalization,
+            size_crops=args.size_crops,
+            nmb_crops=args.nmb_crops,
+            min_scale_crops=args.min_scale_crops,
+            max_scale_crops=args.max_scale_crops,
+            gaussian_blur=args.gaussian_blur,
+            jitter_strength=args.jitter_strength
+        )
+
+        dm.val_transforms = SwAVEvalDataTransform(
+            normalize=normalization,
+            size_crops=args.size_crops,
+            nmb_crops=args.nmb_crops,
+            min_scale_crops=args.min_scale_crops,
+            max_scale_crops=args.max_scale_crops,
+            gaussian_blur=args.gaussian_blur,
+            jitter_strength=args.jitter_strength
+        )
+
+        plotter = DataPlotter(dm)
+        plot_dir = join(root_dir, 'dataloaders')
+        plotter.plot_dataloaders(plot_dir)
+
+        init_weights = args.init_weights
+        if init_weights:
+            model = SwAV.load_from_checkpoint(init_weights, strict=True, **args.__dict__)
+        else:
+            model = SwAV(**args.__dict__)
+
+        csv_logger = pl.loggers.CSVLogger(root_dir, 'csv')
+        tb_logger = pl.loggers.TensorBoardLogger(root_dir, 'tb')
+        loggers = [csv_logger, tb_logger]
+        checkpoint_callback = ModelCheckpoint(root_dir, 'last_epoch')
+        lr_monitor_callback = LearningRateMonitor()
+        callbacks = [checkpoint_callback, lr_monitor_callback]
+        if orig_root_dir.startswith('s3://'):
+            callbacks.append(
+                S3SyncCallback(root_dir, orig_root_dir))
+
+        trainer = pl.Trainer(
+            max_epochs=args.max_epochs,
+            max_steps=None if args.max_steps == -1 else args.max_steps,
+            gpus=args.gpus,
+            num_nodes=args.num_nodes,
+            distributed_backend='ddp' if args.gpus > 1 else None,
+            sync_batchnorm=True if args.gpus > 1 else False,
+            precision=32 if args.fp32 else 16,
+            fast_dev_run=args.fast_dev_run,
+            default_root_dir=args.default_root_dir,
+            callbacks=callbacks,
+            logger=loggers,
+            progress_bar_refresh_rate=args.progress_bar_refresh_rate
+        )
+
+        trainer.fit(model, datamodule=dm)
+
+        backbone_path = join(root_dir, 'backbone.pth')
+        save_backbone(model, backbone_path)
+
+        if orig_root_dir.startswith('s3://'):
+            s3_sync(root_dir, orig_root_dir)
+
+
+def get_arg_parser():
+    parser = ArgumentParser()
+    parser = SwAV.add_model_specific_args(parser)
+    parser.add_argument('--default_root_dir', type=str, default=os.getcwd())
+    parser.add_argument('--init_weights', type=str, default=None)
+    parser.add_argument('--progress_bar_refresh_rate', type=int, default=1)
+    parser.set_defaults(hide_progress_bar=False)
+    return parser
+
+
+if __name__ == '__main__':
+    command = sys.argv
+    if '--aws_batch' in command:
+        command.remove('--aws_batch')
+        command.insert(0, 'python')
+        command.extend(['--progress_bar_refresh_rate', '100'])
+        batch_submit(command)
+        exit()
+
+    parser = get_arg_parser()
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
This runs on Batch and produces a Resnet50 backbone which can then be fine-tuned. This is being used in conjunction with https://github.com/lewfish/ssl/blob/main/spacenet/spacenet_ssl.py. However, the downstream results are slightly worse than when using an Imagenet supervised pretrained backbone, so this needs further work / hyperparameter tuning.

```
export JOB_DEF="lfishgoldPyTorchModelsGpuJobDefinition"
export JOB_QUEUE="lfishgoldRasterVisionGpuJobQueue"
python -m pytorch_models.train_swav \
    --data_dir s3://research-lf-dev/ssl/output-4-5-2021/baselines/spacenet-unsupervised-chips/4-5-2021a/chip \
    --default_root_dir s3://research-lf-dev/ssl/output-4-5-2021/baselines/swav/4-13-2021a/ \
    --max_epochs 4 \
    --batch_size 64 \
    --init_weights s3://research-lf-dev/ssl/checkpoints/swav_imagenet.pth.tar \
    --fast_dev_run 0 --aws_batch
```